### PR TITLE
Remove allocations from in-place broadcasted operations

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -14,7 +14,7 @@ function Base.copyto!(
   bc::Base.Broadcast.Broadcasted{PartitionedVectorStyle},
 )
   bcf = Base.Broadcast.flatten(bc)
-  for i in bcf.axes[1]    
+  for i in bcf.axes[1]
     filtered = _filter(i, bcf.args)
     dest[i].vec .= bcf.f.(filtered...)
   end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -14,10 +14,9 @@ function Base.copyto!(
   bc::Base.Broadcast.Broadcasted{PartitionedVectorStyle},
 )
   bcf = Base.Broadcast.flatten(bc)
-  for i in bcf.axes[1]
+  for i in bcf.axes[1]    
     filtered = _filter(i, bcf.args)
-    res = bcf.f(filtered...)
-    dest[i] = res
+    dest[i].vec .= bcf.f.(filtered...)
   end
   return dest
 end
@@ -32,7 +31,7 @@ end
 Pass through a `Tuple` to select the `i`-th element if necessary.
 """
 _filter(i::Int, arg::Tuple{}) = ()
-_filter(i::Int, arg::PartitionedVector) = arg[i]
+_filter(i::Int, arg::PartitionedVector) = arg[i].vec
 _filter(i::Int, arg::Any) = arg
 _filter(i::Int, args::Tuple) = (_filter(i, args[1]), _filter(i, Base.tail(args))...)
 


### PR DESCRIPTION
@dpo huge news, I successfully removed allocations from inplace broadcasted operations!!

```julia
using BenchmarkTools
using StatsBase
using PartitionedVectors

N = 5000 #elements
n = 20000
nie = 15
element_variables =
  vcat(map((i -> sample(1:n, nie, replace = false)), 1:N))

pv1 = PartitionedVector(element_variables; n)
pv1 .= 1
pv2 = PartitionedVector(element_variables; n)
pv2 .= 2
res = PartitionedVector(element_variables; n)

@benchmark res .= pv1 .+ pv2 .* 2
# BenchmarkTools.Trial: 10000 samples with 1 evaluation.
#  Range (min … max):  78.800 μs … 374.800 μs  ┊ GC (min … max): 0.00% … 0.00%
#  Time  (median):     82.300 μs               ┊ GC (median):    0.00%
#  Time  (mean ± σ):   92.795 μs ±  28.771 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
#   ▄█▂▁▁    ▂▁▂      ▁                                          ▁
#   █████▇█▇▇███▇▆▆▆▅▆███▇▇▇▇▇▇▆▇▆▇▆▅▅▆▅▆▆▅▆▅▅▅▇█▇▇▇▇▆▅▄▅▆▆▆▅▅▄▅ █
#   78.8 μs       Histogram: log(frequency) by time       209 μs <
#  Memory estimate: 128 bytes, allocs estimate: 4.
```

edit: I didn't implement what I taked yesterday about inplace basic operations for element vectors.