### PR TITLE
Add a warning when no element contribute to a variable

### DIFF
--- a/src/struct.jl
+++ b/src/struct.jl
@@ -54,6 +54,9 @@ function build!(pv::PartitionedVector, ::Val{true})
       eev = PS.get_eev_set(epv, index_element)
       val = PS.get_vec_from_indices(eev, i)
       vec[i] = val
+    else 
+      @warn "No element contribute to the $i-th variable. \n Its value in the assocaited Vector is set to 0" 
+      vec[i] = 0
     end
   end
   return pv

--- a/test/base.jl
+++ b/test/base.jl
@@ -69,3 +69,13 @@ end
   pv .= 1
   @test Vector(pv) == ones(n)
 end
+
+@testset "warning build" begin
+  N = 5
+  n = 8
+  element_variables = [[1, 2, 3, 4], [3, 4, 5, 6], [5, 6, 7], [5, 6, 4], Int[]]
+
+  pv = PartitionedVector(element_variables; simulate_vector = true, n)
+
+  build!(pv)
+end


### PR DESCRIPTION
@dpo small changes to get a warning if no element contribute to a variable.
example:

$$ f(x) = f_1(x_1,x_2) + f_(x_4, x_5) $$

no element contribute to $x_3$.
But it worsen the performance when it happens, what do you prefer?