### PR TITLE
Keyword argument to disable @warn from `build!`

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -89,8 +89,8 @@ copy(pv::PartitionedVector{T}; simulate_vector::Bool = pv.simulate_vector) where
 similar(pv::PartitionedVector{T}; simulate_vector::Bool = pv.simulate_vector) where {T <: Number} =
   PartitionedVector{T}(similar(pv.epv), simulate_vector)
 
-function Base.Vector(pv::PartitionedVector{T}) where {T}
-  build!(pv)
+function Base.Vector(pv::PartitionedVector{T}; kwargs...) where {T}
+  build!(pv; kwargs...)
   vector = pv.epv.v
   return Vector{T}(copy(vector))
 end

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -76,10 +76,11 @@ function axpby!(
   t::Y2,
   y::PartitionedVector{T},
   ::Val{false},
-  ::Val{true},
+  ::Val{true};
+  kwargs...
 ) where {T <: Number, Y1 <: Number, Y2 <: Number}
-  build!(x)
-  build!(y)
+  build!(x; kwargs...)
+  build!(y; kwargs...)
   xvector = x.epv.v
   yvector = y.epv.v
   axpby!(s, xvector, t, yvector)

--- a/src/linearAlgebra.jl
+++ b/src/linearAlgebra.jl
@@ -2,15 +2,15 @@ import Base.*
 import LinearAlgebra.mul!
 import LinearAlgebra: norm, dot
 
-function norm(pv::PartitionedVector, p::Real = 2)
-  build!(pv)
+function norm(pv::PartitionedVector, p::Real = 2; kwargs...)
+  build!(pv; kwargs...)
   _norm = norm(get_v(pv.epv), p)
   return _norm
 end
 
-function dot(pv1::PartitionedVector{T}, pv2::PartitionedVector{T}) where {T}
-  build!(pv1)
-  build!(pv2)
+function dot(pv1::PartitionedVector{T}, pv2::PartitionedVector{T}; kwargs...) where {T}
+  build!(pv1; kwargs...)
+  build!(pv2; kwargs...)
   dot(get_v(pv1.epv), get_v(pv2.epv))
 end
 

--- a/src/struct.jl
+++ b/src/struct.jl
@@ -40,11 +40,11 @@ If `pv.simulate=false`, it aggregates contributions from elemental vectors.
 If `pv.simulate=true`, common variables among element vectors value the same.
 For each index 1 ≤ `i` ≤ n, , `build!` will take the first element containing `i` and sets `pv.epv.v[i]` to its value.
 """
-build!(pv::PartitionedVector) = build!(pv, Val(pv.simulate_vector))
+build!(pv::PartitionedVector; kwargs...) = build!(pv, Val(pv.simulate_vector); kwargs...)
 
 build!(pv::PartitionedVector, ::Val{false}) = build_v!(pv.epv)
 
-function build!(pv::PartitionedVector, ::Val{true})
+function build!(pv::PartitionedVector, ::Val{true}; warn::Bool=true)
   epv = pv.epv
   vec = epv.v
   component_list = epv.component_list
@@ -55,7 +55,7 @@ function build!(pv::PartitionedVector, ::Val{true})
       val = PS.get_vec_from_indices(eev, i)
       vec[i] = val
     else 
-      @warn "No element contribute to the $i-th variable. \n Its value in the assocaited Vector is set to 0" 
+      warn && @warn "No element contribute to the $i-th variable. \n Its value in the assocaited Vector is set to 0" 
       vec[i] = 0
     end
   end

--- a/test/base.jl
+++ b/test/base.jl
@@ -79,3 +79,15 @@ end
 
   build!(pv)
 end
+
+@testset "disabling warning build" begin
+  N = 5
+  n = 8
+  element_variables = [[1, 2, 3, 4], [3, 4, 5, 6], [5, 6, 7], [5, 6, 4], Int[]]
+
+  pv = PartitionedVector(element_variables; simulate_vector = true, n)
+
+  build!(pv; warn=false)
+  norm(pv; warn=false)
+  dot(pv, pv; warn=false)
+end


### PR DESCRIPTION
@dpo I added this keyword argument to disable warning from `build!` consequently to #25.
I did not change default behaviour of `build!`, which warns when no element contribute to a variable. 
I made this change because it is really convenient for me to use 
```julia
N = 1500
n = 20000
nie = 50
element_variables = map((i -> sample(1:n, nie, replace = false)), 1:N)

pv = PartitionedVector(element_variables)
```
to define a large PartitionedVector.
It is usefull to push the limits of PartitionedVectors.
Unfortunately, I can't ensure that `element_variables` get every component between `1:n`, that why I added the keyword argument.