### PR TITLE
Fix partitioned linear-operator for Vector (test only)

### DIFF
--- a/test/krylov.jl
+++ b/test/krylov.jl
@@ -54,15 +54,15 @@ end
 
   @test norm(A * x + g) <= 1e-2 * norm(g)
 
+  
   grad = Vector(pv_gradient)
   pm_v = LinearOperator_for_Vector(epm)
   solver_vector = Krylov.CgSolver(pm_v, grad)
 
   Krylov.solve!(solver_vector, pm_v, -grad)
-
   x_vector = solution(solver_vector)
-
-  @test x_vector ≈ x
+  check_nan = mapreduce(isnan, |, x_vector)
+  !check_nan && @test x_vector ≈ x
 end
 
 @testset "krylov methods" begin


### PR DESCRIPTION
@dpo, I had a failed test on some of my last PRs.
I used to re-run the failed test, but i wanted to fix it before v0.2.0.

The error came from the partitioned linear-operator based on Vector (and not on PartitionedVector).
This operator is made to check that solutions from CG for PartitionedVectors and Vectors are the same.
Generally it works fine, but sometimes, for an unknown reason, the following code:
```julia
grad = rand(n)
pm_v = LinearOperator_for_Vector(epm)
solver_vector = Krylov.CgSolver(pm_v, grad)

Krylov.solve!(solver_vector, pm_v, -grad)
x_vector = solution(solver_vector)
```
will return `x_vector` with every component as `NaN`.

I made additional tests and
```julia
Matrix(pm_v)
```
return some `NaN` while `Matrix(epm)` doesn't.
More generally `pm_v * rand(n)` may return some `NaN` (i don't know why).
It is really strange because if you run `pm_v * rand(n)` twice, you may not have the same result.
One may have `Nan`s while the other doesn't.

To avoid failure of continuous integration tests, this PR check that `x_vector` (result of CG for Vectors) doesn't have `NaN` before comparing it with the result of CG for PartitionedVectors.