### PR TITLE
Improve `build!`

### DIFF
--- a/src/struct.jl
+++ b/src/struct.jl
@@ -47,16 +47,13 @@ build!(pv::PartitionedVector, ::Val{false}) = build_v!(pv.epv)
 function build!(pv::PartitionedVector, ::Val{true}; warn::Bool=true)
   epv = pv.epv
   vec = epv.v
-  component_list = epv.component_list
-  for i = 1:length(vec)
-    if !isempty(component_list[i])
-      index_element = component_list[i][1]
-      eev = PS.get_eev_set(epv, index_element)
-      val = PS.get_vec_from_indices(eev, i)
-      vec[i] = val
-    else 
-      warn && @warn "No element contribute to the $i-th variable. \n Its value in the assocaited Vector is set to 0" 
-      vec[i] = 0
+  N = epv.N
+  vec .= 0
+  for i = 1:N
+    eevi = pv[i].vec
+    indices = pv[i].indices
+    for (index,j) in enumerate(indices)
+      vec[j] = eevi[index]
     end
   end
   return pv


### PR DESCRIPTION
#24 

See below for the gain:
```julia
N = 1500
n = 20000
nie = 15
element_variables = map((i -> sample(1:n, nie, replace = false)), 1:N)

pv_vec = PartitionedVector(element_variables; n, simulate_vector=true)
v = [1.:n;]
set!(pv_vec, v)

@benchmark build!(pv_vec; warn=false)
# master 
# BenchmarkTools.Trial: 7563 samples with 1 evaluation.
#  Range (min … max):  546.800 μs …   2.445 ms  ┊ GC (min … max): 0.00% … 0.00%
#  Time  (median):     616.200 μs               ┊ GC (median):    0.00%
#  Time  (mean ± σ):   658.202 μs ± 135.920 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
#   ▃███████▇▆▅▄▃▄▄▅▄▃▂▂▁▁▁▁▁▁▁ ▁▁▁ ▁▁  ▁ ▁                       ▃
#   █████████████████████████████████████████▇████▇█▇▇▇▆▇▇█▅▇▆▄▅▆ █
#   547 μs        Histogram: log(frequency) by time       1.18 ms <
#  Memory estimate: 0 bytes, allocs estimate: 0.

# current branch
# BenchmarkTools.Trial: 10000 samples with 1 evaluation.
#  Range (min … max):  28.500 μs … 218.900 μs  ┊ GC (min … max): 0.00% … 0.00%
#  Time  (median):     28.900 μs               ┊ GC (median):    0.00%
#  Time  (mean ± σ):   32.789 μs ±  13.152 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
#   █▃▁▃▁        ▂  ▂                                            ▁
#   █████▇▇▇▇▆▅▄▆█▇██▇▅▄▅▅▄▃▄▄▅▇█████▆▆▆▅▅▅▅▅▆▅▁▃▁▃▄▄▁▁▁▁▁▁▄▆▆▆▆ █
#   28.5 μs       Histogram: log(frequency) by time       106 μs <
#  Memory estimate: 0 bytes, allocs estimate: 0.
```
